### PR TITLE
upload test data for `synced_up_to_260241`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+stakedb/synced_up_to_260241/test-data\.db

--- a/stakedb/synced_up_to_260241/test-description.json
+++ b/stakedb/synced_up_to_260241/test-description.json
@@ -1,4 +1,6 @@
 {
-    "test_name": "synced_up_to_260241",
-    "expected_block_height": 260241
+  "test_name": "synced_up_to_260241",
+  "expected_block_height": 260241,
+  "expected_stake_info_height": 260241,
+  "expected_best_block_hash": "0000000000000000aeaa610cd2ba4ee1e9fc6f370c1fb5bed7fcd25a79fceea3"
 }

--- a/stakedb/synced_up_to_260241/test-description.json
+++ b/stakedb/synced_up_to_260241/test-description.json
@@ -1,0 +1,4 @@
+{
+    "test_name": "synced_up_to_260241",
+    "expected_block_height": 260241
+}


### PR DESCRIPTION
Proposed structure:
 - Each test has a dedicated folder inside the `stakedb` folder. The folder name is also the test name. Example: the `synced_up_to_260241`.
 - Inside each test folder, there is compressed db file `test-data.zip`. Unpacking it gives `test-data.db` file.
 - Also there is the `test-description.json` containing information related to the test: name, expected values and so on.

![image](https://user-images.githubusercontent.com/1580663/43343592-173527c4-91e7-11e8-9822-ebc7c92f6cb8.png)

`synced_up_to_260241` - is a fully synced db up to the block `# 260241`

 